### PR TITLE
getProtocolText additional ID

### DIFF
--- a/DRBDBReader/DB/Database.cs
+++ b/DRBDBReader/DB/Database.cs
@@ -304,6 +304,8 @@ namespace DRBDBReader.DB
 					return "CCD";
 				case 60:
 					return "SCI";
+				case 103:
+					return "ISO";
 				case 159:
 					return "Multimeter";
 				case 160:


### PR DESCRIPTION
Some ABS modules don't have CCD-bus connection, so they communicate over a single ISO-line (which is the SCI TX line) at probably 10.4 kbps.
Teves Module ID CCD over ISO: P103; xmit: B2-43-24-01-00; sc: Antilock Brakes; 0x8000539d